### PR TITLE
fos_js_routes is no longer suffixed in prod environment

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -34,7 +34,7 @@ namespace :fos do
         task :dump do
             on roles(:app) do
                 execute "cd #{release_path} && php " + fetch(:symfony_console_path) + " --env=prod fos:js-routing:dump --target=web/js/fos_js_routes.js"
-                execute "cp web/js/fos_js_routes.js web/js/fos_js_routes_prod.js"
+                execute "cd #{release_path} && cp web/js/fos_js_routes.js web/js/fos_js_routes_prod.js"
             end
         end
     end

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -33,7 +33,8 @@ namespace :fos do
         DESC
         task :dump do
             on roles(:app) do
-                execute "cd #{release_path} && php " + fetch(:symfony_console_path) + " --env=prod fos:js-routing:dump --target=web/js/fos_js_routes_prod.js"
+                execute "cd #{release_path} && php " + fetch(:symfony_console_path) + " --env=prod fos:js-routing:dump --target=web/js/fos_js_routes.js"
+                execute "cp web/js/fos_js_routes.js web/js/fos_js_routes_prod.js"
             end
         end
     end


### PR DESCRIPTION
the existing suffix is kept but deprecated.
See Victoire/victoire PR 1052 for the matching change